### PR TITLE
servarr-ffmpeg: init at 5.1.4

### DIFF
--- a/pkgs/by-name/ra/radarr/package.nix
+++ b/pkgs/by-name/ra/radarr/package.nix
@@ -6,7 +6,7 @@
   dotnetCorePackages,
   sqlite,
   withFFmpeg ? true, # replace bundled ffprobe binary with symlink to ffmpeg package.
-  ffmpeg,
+  servarr-ffmpeg,
   fetchYarnDeps,
   yarn,
   fixup-yarn-lock,
@@ -71,7 +71,7 @@ buildDotnetModule {
     hash = "sha256-lxOmheBRqVI39I6fOoXWpGhb1fseHC8Mo/KhbRRYHI8=";
   };
 
-  ffprobe = lib.optionalDrvAttr withFFmpeg (lib.getExe' ffmpeg "ffprobe");
+  ffprobe = lib.optionalDrvAttr withFFmpeg (lib.getExe' servarr-ffmpeg "ffprobe");
 
   postConfigure = ''
     yarn config --offline set yarn-offline-mirror "$yarnOfflineCache"

--- a/pkgs/by-name/se/servarr-ffmpeg/package.nix
+++ b/pkgs/by-name/se/servarr-ffmpeg/package.nix
@@ -1,0 +1,112 @@
+{
+  ffmpeg-headless,
+  fetchFromGitHub,
+  fetchpatch2,
+  lib,
+}:
+
+let
+  version = "5.1.4";
+in
+
+(ffmpeg-headless.override {
+  inherit version; # Important! This sets the ABI.
+
+  # Fetch commit hash from this repository: https://github.com/Servarr/ffmpeg-build
+  # Compare build logs to upstream logs here: https://dev.azure.com/Servarr/Servarr/_build?definitionId=15
+  source = fetchFromGitHub {
+    owner = "Servarr";
+    repo = "FFmpeg";
+    rev = "e9230b4c9027435dd402a68833f144643a3df43a";
+    hash = "sha256-oMIblMOnnYpKvYeleCZpFZURGVc3fDAlYpOJu+u7HkU=";
+  };
+
+  buildFfmpeg = false;
+  buildFfplay = false;
+  buildAvdevice = false;
+  buildAvfilter = false;
+  buildPostproc = false;
+  buildSwresample = false;
+  buildSwscale = false;
+
+  withAlsa = false;
+  withAmf = false;
+  withAom = false;
+  withAss = false;
+  withBluray = false;
+  withBzlib = false;
+  withCudaLLVM = false;
+  withCuvid = false;
+  withDrm = false;
+  withNvcodec = false;
+  withFontconfig = false;
+  withFreetype = false;
+  withFribidi = false;
+  withGnutls = false;
+  withIconv = false;
+  withLzma = false;
+  withMp3lame = false;
+  withOpencl = false;
+  withOpenjpeg = false;
+  withOpenmpt = false;
+  withOpus = false;
+  withRist = false;
+  withSoxr = false;
+  withSpeex = false;
+  withSrt = false;
+  withSsh = false;
+  withSvtav1 = false;
+  withTheora = false;
+  withV4l2 = false;
+  withVaapi = false;
+  withVidStab = false;
+  withVorbis = false;
+  withVpx = false;
+  withVulkan = false;
+  withWebp = false;
+  withX264 = false;
+  withX265 = false;
+  withXml2 = false;
+  withXvid = false;
+  withZimg = false;
+  withZlib = false;
+  withZvbi = false;
+}).overrideAttrs
+  (old: {
+    pname = "servarr-ffmpeg";
+
+    patches = old.patches ++ [
+      (fetchpatch2 {
+        name = "fix_build_failure_due_to_libjxl_version_to_new";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/75b1a555a70c178a9166629e43ec2f6250219eb2";
+        hash = "sha256-+2kzfPJf5piim+DqEgDuVEEX5HLwRsxq0dWONJ4ACrU=";
+      })
+    ];
+
+    configureFlags = old.configureFlags ++ [
+      "--extra-version=Servarr"
+
+      # https://github.com/Servarr/ffmpeg-build/blob/bc29af6f0bf84bf9253d4d462611b1dc31ee688e/common.sh#L15-L45
+
+      # Disable unused functionnalities
+      "--disable-encoders"
+      "--disable-muxers"
+      "--disable-protocols"
+      "--disable-bsfs"
+
+      # FFMpeg options - enable what we need
+      "--enable-protocol=file"
+      "--enable-bsf=av1_frame_split"
+      "--enable-bsf=av1_frame_merge"
+      "--enable-bsf=av1_metadata"
+    ];
+
+    doCheck = false;
+
+    meta = {
+      inherit (old.meta) license mainProgram;
+      description = "${old.meta.description} (Servarr fork)";
+      homepage = "https://github.com/Servarr/FFmpeg";
+      maintainers = with lib.maintainers; [ nyanloutre ];
+    };
+  })

--- a/pkgs/by-name/so/sonarr/package.nix
+++ b/pkgs/by-name/so/sonarr/package.nix
@@ -6,7 +6,7 @@
   dotnetCorePackages,
   sqlite,
   withFFmpeg ? true, # replace bundled ffprobe binary with symlink to ffmpeg package.
-  ffmpeg,
+  servarr-ffmpeg,
   fetchYarnDeps,
   yarn,
   fixup-yarn-lock,
@@ -72,7 +72,7 @@ buildDotnetModule {
     hash = "sha256-YkBFvv+g4p22HdM/GQAHVGGW1yLYGWpNtRq7+QJiLIw=";
   };
 
-  ffprobe = lib.optionalDrvAttr withFFmpeg (lib.getExe' ffmpeg "ffprobe");
+  ffprobe = lib.optionalDrvAttr withFFmpeg (lib.getExe' servarr-ffmpeg "ffprobe");
 
   postConfigure = ''
     yarn config --offline set yarn-offline-mirror "$yarnOfflineCache"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
